### PR TITLE
Bring action versions up to date

### DIFF
--- a/.github/workflows/test-py39-unit.yaml
+++ b/.github/workflows/test-py39-unit.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 


### PR DESCRIPTION
The workflow was using outdated versions of GitHub actions and this brings them up to date. (From #4)