### PR TITLE
SCIM v2 API to Add/Remove Users to Group

### DIFF
--- a/src/coldfront_plugin_api/auth.py
+++ b/src/coldfront_plugin_api/auth.py
@@ -1,0 +1,9 @@
+import os
+
+from rest_framework.authentication import SessionAuthentication, BasicAuthentication
+from mozilla_django_oidc.contrib.drf import OIDCAuthentication
+
+if os.getenv('PLUGIN_AUTH_OIDC') == 'True':
+    AUTHENTICATION_CLASSES = [OIDCAuthentication, SessionAuthentication]
+else:
+    AUTHENTICATION_CLASSES = [SessionAuthentication, BasicAuthentication]

--- a/src/coldfront_plugin_api/scim_v2/groups.py
+++ b/src/coldfront_plugin_api/scim_v2/groups.py
@@ -1,0 +1,114 @@
+from coldfront.core.allocation import signals
+from coldfront.core.allocation.models import Allocation, AllocationUser, AllocationUserStatusChoice
+from django.contrib.auth.models import User
+from rest_framework.views import APIView
+from rest_framework.permissions import IsAdminUser
+from rest_framework.response import Response
+
+from coldfront_plugin_api import auth
+
+
+def allocation_to_group_view(allocation: Allocation) -> dict:
+    return {
+        "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+        "id": allocation.pk,
+        "displayName": f"Members of allocation {allocation.pk} of project {allocation.project.title}",
+        "members": [
+            {
+                "value": x.user.username,
+                "$ref": x.user.username,
+                "display": x.user.username,
+            } for x in AllocationUser.objects.filter(allocation=allocation,status__name="Active")
+        ]
+    }
+
+
+class ListGroups(APIView):
+    """
+    View to list all groups in the system.
+
+    * Requires token authentication.
+    * Only admin users are able to access this view.
+    """
+    authentication_classes = auth.AUTHENTICATION_CLASSES
+    permission_classes = [IsAdminUser]
+
+    def get(self, request, format=None):
+        """
+        Return a list of all groups.
+        """
+        allocations = Allocation.objects.filter(status__name="Active")
+        return Response(
+            [allocation_to_group_view(allocation) for allocation in allocations]
+        )
+
+
+class GroupDetail(APIView):
+    """
+    View to list all groups in the system.
+
+    * Requires token authentication.
+    * Only admin users are able to access this view.
+    """
+    authentication_classes = auth.AUTHENTICATION_CLASSES
+    permission_classes = [IsAdminUser]
+
+    def get(self, request, pk, format=None):
+        allocation = Allocation.objects.get(pk=pk)
+        return Response(allocation_to_group_view(allocation))
+
+    def patch(self, request, pk, format=None):
+        if (
+                request.data["schemas"] != ["urn:ietf:params:scim:api:messages:2.0:PatchOp"]
+                or request.data.get("path", "members") != "members"
+        ):
+            return Response(status=400)
+
+        allocation = Allocation.objects.get(pk=pk)
+        for operation in request.data["Operations"]:
+            value = operation["value"]
+            if type(value) == dict:
+                value = [x["value"] for x in operation["value"]["members"]]
+            elif type(value) == list:
+                value = [x["value"] for x in operation["value"]]
+
+            if operation["op"] == "add":
+                for submitted_user in value:
+                    user = User.objects.get(username=submitted_user)
+                    au = self._set_user_status_on_allocation(
+                        allocation, user, "Active"
+                    )
+                    signals.allocation_activate_user.send(
+                        sender=self.__class__, allocation_user_pk=au.pk,
+                    )
+            elif operation["op"] == "remove":
+                for submitted_user in value:
+                    user = User.objects.get(username=submitted_user)
+                    au = self._set_user_status_on_allocation(
+                        allocation, user, "Removed"
+                    )
+                    signals.allocation_remove_user.send(
+                        sender=self.__class__, allocation_user_pk=au.pk,
+                    )
+            else:
+                # Replace is not implemented yet.
+                raise NotImplementedError
+
+        return Response(allocation_to_group_view(allocation))
+
+    @staticmethod
+    def _set_user_status_on_allocation(allocation, user, status):
+        au = AllocationUser.objects.filter(
+            allocation=allocation,
+            user=user
+        ).first()
+        if au:
+            au.status = AllocationUserStatusChoice.objects.get(name=status)
+            au.save()
+        else:
+            au = AllocationUser.objects.create(
+                allocation=allocation,
+                user=user,
+                status=AllocationUserStatusChoice.objects.get(name=status)
+            )
+        return au

--- a/src/coldfront_plugin_api/tests/unit/base.py
+++ b/src/coldfront_plugin_api/tests/unit/base.py
@@ -1,0 +1,79 @@
+import sys
+from os import devnull
+import uuid
+
+from coldfront.core.allocation.models import (Allocation,
+                                              AllocationStatusChoice,
+                                              AllocationUser,
+                                              AllocationUserStatusChoice)
+
+from django.contrib.auth.models import User
+from coldfront.core.project.models import (Project,
+                                           ProjectUser,
+                                           ProjectUserRoleChoice,
+                                           ProjectUserStatusChoice, ProjectStatusChoice)
+from coldfront.core.resource.models import (Resource,
+                                            ResourceType,
+                                            ResourceAttribute,
+                                            ResourceAttributeType)
+from django.core.management import call_command
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from coldfront_plugin_cloud import attributes
+
+
+class TestBase(TestCase):
+
+    def setUp(self) -> None:
+        # Otherwise output goes to the terminal for every test that is run
+        backup, sys.stdout = sys.stdout, open(devnull, 'a')
+        call_command('initial_setup', '-f')
+        call_command('load_test_data')
+        call_command('register_cloud_attributes')
+        sys.stdout = backup
+
+    @staticmethod
+    def new_user(username=None) -> User:
+        username = username or f'{uuid.uuid4().hex}@example.com'
+        User.objects.create(username=username, email=username)
+        return User.objects.get(username=username)
+
+    def new_project(self, title=None, pi=None) -> Project:
+        title = title or uuid.uuid4().hex
+        pi = pi or self.new_user()
+        status = ProjectStatusChoice.objects.get(name='New')
+
+        Project.objects.create(title=title, pi=pi, status=status)
+        return Project.objects.get(title=title)
+
+    @staticmethod
+    def new_project_user(user, project, role='Manager', status='Active'):
+        pu, _ = ProjectUser.objects.get_or_create(
+            user=user,
+            project=project,
+            role=ProjectUserRoleChoice.objects.get(name=role),
+            status=ProjectUserStatusChoice.objects.get(name=status)
+        )
+        return pu
+
+    @staticmethod
+    def new_allocation(project, resource, quantity):
+        allocation, _ = Allocation.objects.get_or_create(
+            project=project,
+            justification='a justification for testing data',
+            quantity=quantity,
+            status=AllocationStatusChoice.objects.get(
+                name='Active')
+        )
+        allocation.resources.add(resource)
+        return allocation
+
+    @staticmethod
+    def new_allocation_user(allocation, user):
+        au, _ = AllocationUser.objects.get_or_create(
+            allocation=allocation,
+            user=user,
+            status=AllocationUserStatusChoice.objects.get(name='Active')
+        )
+        return au

--- a/src/coldfront_plugin_api/tests/unit/test_allocations.py
+++ b/src/coldfront_plugin_api/tests/unit/test_allocations.py
@@ -36,7 +36,7 @@ class TestAllocation(base.TestBase):
         project = self.new_project(pi=user)
         allocation = self.new_allocation(project, self.resource, 1)
 
-        response = self.admin_client.get("/api/allocations/")
+        response = self.admin_client.get("/api/allocations")
         self.assertEqual(response.status_code, 200)
         self.assertIn(allocation.id, [a["id"] for a in response.json()])
 
@@ -52,11 +52,11 @@ class TestAllocation(base.TestBase):
         self.assertEqual(allocation.status.name, "Expired")
 
         # Expired allocation will not display without ?all query
-        response = self.admin_client.get("/api/allocations/")
+        response = self.admin_client.get("/api/allocations")
         self.assertEqual(response.status_code, 200)
         self.assertNotIn(allocation.id, [a["id"] for a in response.json()])
 
         # Expired allocation shows up when using ?all query
-        response = self.admin_client.get("/api/allocations/?all=true")
+        response = self.admin_client.get("/api/allocations?all=true")
         self.assertEqual(response.status_code, 200)
         self.assertIn(allocation.id, [a["id"] for a in response.json()])

--- a/src/coldfront_plugin_api/tests/unit/test_groups.py
+++ b/src/coldfront_plugin_api/tests/unit/test_groups.py
@@ -1,0 +1,119 @@
+import json
+import os
+import unittest
+from os import devnull
+import sys
+
+from coldfront_plugin_api import urls
+from coldfront_plugin_api.tests.unit import base
+
+from coldfront.core.resource import models as resource_models
+from coldfront.core.allocation import models as allocation_models
+from django.core.management import call_command
+from rest_framework.test import APIClient
+
+
+class TestAllocation(base.TestBase):
+
+    def setUp(self) -> None:
+        self.maxDiff = None
+        super().setUp()
+        self.resource = resource_models.Resource.objects.all().first()
+
+    @property
+    def admin_client(self):
+        client = APIClient()
+        client.login(username='admin', password='test1234')
+        return client
+
+    def test_list_groups(self):
+        user = self.new_user()
+        project = self.new_project(pi=user)
+        allocation = self.new_allocation(project, self.resource, 1)
+
+        response = self.admin_client.get("/api/scim/v2/Groups")
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_group(self):
+        user = self.new_user()
+        project = self.new_project(pi=user)
+        allocation = self.new_allocation(project, self.resource, 1)
+
+        response = self.admin_client.get(f"/api/scim/v2/Groups/{allocation.id}")
+
+        desired_response = {
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+            "id": allocation.id,
+            "displayName": f"Members of allocation {allocation.id} of project {allocation.project.title}",
+            "members": []
+        }
+        self.assertEqual(response.json(), desired_response)
+
+    def test_add_remove_group_members(self):
+        user = self.new_user()
+        project = self.new_project(pi=user)
+        allocation = self.new_allocation(project, self.resource, 1)
+
+        payload = {
+            "schemas": [
+                "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+            ],
+            "Operations": [
+                {
+                    "op": "add",
+                    "value": {
+                        "members": [
+                            {
+                                "value": user.username
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+        response = self.admin_client.patch(f"/api/scim/v2/Groups/{allocation.id}",
+                                           data=payload,
+                                           format="json")
+        self.assertEqual(response.status_code, 200)
+
+        desired_response = {
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+            "id": allocation.id,
+            "displayName": f"Members of allocation {allocation.id} of project {allocation.project.title}",
+            "members": [{
+                "value": user.username,
+                "$ref": user.username,
+                "display": user.username,
+            }]
+        }
+        response = self.admin_client.get(f"/api/scim/v2/Groups/{allocation.id}")
+        self.assertEqual(response.json(), desired_response)
+
+        payload = {
+            "schemas": [
+                "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+            ],
+            "Operations": [
+                {
+                    "op": "remove",
+                    "value": {
+                        "members": [
+                            {
+                                "value": user.username
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+        response = self.admin_client.patch(f"/api/scim/v2/Groups/{allocation.id}",
+                                           data=payload,
+                                           format="json")
+        desired_response = {
+            "schemas": ["urn:ietf:params:scim:schemas:core:2.0:Group"],
+            "id": allocation.id,
+            "displayName": f"Members of allocation {allocation.id} of project {allocation.project.title}",
+            "members": []
+        }
+        self.assertEqual(response.json(), desired_response)

--- a/src/coldfront_plugin_api/urls.py
+++ b/src/coldfront_plugin_api/urls.py
@@ -4,6 +4,9 @@ from rest_framework.permissions import IsAdminUser
 from coldfront.core.allocation.models import Allocation
 
 from coldfront_plugin_api import auth, serializers
+from coldfront_plugin_api.scim_v2 import groups
+from django.urls import path
+from rest_framework.urlpatterns import format_suffix_patterns
 
 
 class AllocationViewSet(viewsets.ReadOnlyModelViewSet):
@@ -24,3 +27,9 @@ router = routers.SimpleRouter(trailing_slash=False)
 router.register(r'allocations', AllocationViewSet, basename='api-allocation')
 
 urlpatterns = router.urls
+
+urlpatterns += [
+    path('scim/v2/Groups', groups.ListGroups.as_view()),
+    path('scim/v2/Groups/<int:pk>', groups.GroupDetail.as_view()),
+]
+urlpatterns = format_suffix_patterns(urlpatterns)

--- a/src/coldfront_plugin_api/urls.py
+++ b/src/coldfront_plugin_api/urls.py
@@ -1,23 +1,14 @@
-import os
-
 from rest_framework import routers, viewsets
-from rest_framework.authentication import SessionAuthentication, BasicAuthentication
 from rest_framework.permissions import IsAdminUser
-from mozilla_django_oidc.contrib.drf import OIDCAuthentication
 
 from coldfront.core.allocation.models import Allocation
 
-from coldfront_plugin_api import serializers
-
-if os.getenv('PLUGIN_AUTH_OIDC') == 'True':
-    AUTHENTICATION_CLASSES = [OIDCAuthentication, SessionAuthentication]
-else:
-    AUTHENTICATION_CLASSES = [SessionAuthentication, BasicAuthentication]
+from coldfront_plugin_api import auth, serializers
 
 
 class AllocationViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = serializers.AllocationSerializer
-    authentication_classes = AUTHENTICATION_CLASSES
+    authentication_classes = auth.AUTHENTICATION_CLASSES
     permission_classes = [IsAdminUser]
 
     def get_queryset(self):

--- a/src/coldfront_plugin_api/urls.py
+++ b/src/coldfront_plugin_api/urls.py
@@ -20,7 +20,7 @@ class AllocationViewSet(viewsets.ReadOnlyModelViewSet):
         return queryset
 
 
-router = routers.SimpleRouter()
+router = routers.SimpleRouter(trailing_slash=False)
 router.register(r'allocations', AllocationViewSet, basename='api-allocation')
 
 urlpatterns = router.urls


### PR DESCRIPTION
This PR introduces support for querying the `Groups` portion of the [SCIM v2 API](http://simplecloud.info) under the `/scim/v2/Groups` path.

- Listing groups will give a list of Resource Allocations present on the system.
- Adding or removing a user from a group will add or remove the user from that Resource Allocation.
- There is not yet support for creating users, that will come in a follow-up patch. 



