### PR TITLE
Allow fetching user information from search providers (Keycloak) when adding to a group

### DIFF
--- a/src/coldfront_plugin_api/scim_v2/groups.py
+++ b/src/coldfront_plugin_api/scim_v2/groups.py
@@ -1,11 +1,12 @@
 from coldfront.core.allocation import signals
 from coldfront.core.allocation.models import Allocation, AllocationUser, AllocationUserStatusChoice
 from django.contrib.auth.models import User
+from django.core.exceptions import ObjectDoesNotExist
 from rest_framework.views import APIView
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 
-from coldfront_plugin_api import auth
+from coldfront_plugin_api import auth, utils
 
 
 def allocation_to_group_view(allocation: Allocation) -> dict:
@@ -74,7 +75,11 @@ class GroupDetail(APIView):
 
             if operation["op"] == "add":
                 for submitted_user in value:
-                    user = User.objects.get(username=submitted_user)
+                    try:
+                        user = utils.get_or_fetch_user(username=submitted_user)
+                    except ObjectDoesNotExist:
+                        return Response(status=400)
+
                     au = self._set_user_status_on_allocation(
                         allocation, user, "Active"
                     )

--- a/src/coldfront_plugin_api/tests/unit/fakes.py
+++ b/src/coldfront_plugin_api/tests/unit/fakes.py
@@ -1,0 +1,23 @@
+FAKE_USERS = {
+    "fake-user-1": {
+        "username": "fake-user-1",
+        "first_name": "fake",
+        "last_name": "user 1",
+        "email": "fake_user_1@example.com"
+    }
+}
+
+
+class FakeUserSearch():
+    def __init__(self, user_search_string, search_by, **kwargs):
+        self.user_search_string = user_search_string
+
+    def search(self):
+        matches = []
+
+        if match := FAKE_USERS.get(self.user_search_string):
+            matches.append(match)
+
+        return {
+            "matches": matches
+        }

--- a/src/coldfront_plugin_api/tests/unit/test_groups.py
+++ b/src/coldfront_plugin_api/tests/unit/test_groups.py
@@ -1,18 +1,10 @@
-import json
-import os
-import unittest
 from unittest import mock
 import uuid
-from os import devnull
-import sys
-
-from coldfront_plugin_api import urls
-from coldfront_plugin_api.tests.unit import base, fakes
 
 from coldfront.core.resource import models as resource_models
-from coldfront.core.allocation import models as allocation_models
-from django.core.management import call_command
 from rest_framework.test import APIClient
+
+from coldfront_plugin_api.tests.unit import base, fakes
 
 
 class TestAllocation(base.TestBase):

--- a/src/coldfront_plugin_api/tests/unit/test_groups.py
+++ b/src/coldfront_plugin_api/tests/unit/test_groups.py
@@ -131,7 +131,7 @@ class TestAllocation(base.TestBase):
         }
         self.assertEqual(response.json(), desired_response)
 
-    def test_normal_user_fobidden(self):
+    def test_normal_user_forbidden(self):
         response = self.logged_in_user_client.get(f"/api/scim/v2/Groups")
         self.assertEqual(response.status_code, 403)
 

--- a/src/coldfront_plugin_api/tests/unit/test_groups.py
+++ b/src/coldfront_plugin_api/tests/unit/test_groups.py
@@ -7,6 +7,26 @@ from rest_framework.test import APIClient
 from coldfront_plugin_api.tests.unit import base, fakes
 
 
+def get_payload_for_single_operation(operation, username):
+    return {
+        "schemas": [
+            "urn:ietf:params:scim:api:messages:2.0:PatchOp"
+        ],
+        "Operations": [
+            {
+                "op": operation,
+                "value": {
+                    "members": [
+                        {
+                            "value": username
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+
+
 class TestAllocation(base.TestBase):
 
     def setUp(self) -> None:
@@ -62,23 +82,7 @@ class TestAllocation(base.TestBase):
         project = self.new_project(pi=user)
         allocation = self.new_allocation(project, self.resource, 1)
 
-        payload = {
-            "schemas": [
-                "urn:ietf:params:scim:api:messages:2.0:PatchOp"
-            ],
-            "Operations": [
-                {
-                    "op": "add",
-                    "value": {
-                        "members": [
-                            {
-                                "value": user.username
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
+        payload = get_payload_for_single_operation("add", user.username)
         response = self.admin_client.patch(f"/api/scim/v2/Groups/{allocation.id}",
                                            data=payload,
                                            format="json")
@@ -97,23 +101,7 @@ class TestAllocation(base.TestBase):
         response = self.admin_client.get(f"/api/scim/v2/Groups/{allocation.id}")
         self.assertEqual(response.json(), desired_response)
 
-        payload = {
-            "schemas": [
-                "urn:ietf:params:scim:api:messages:2.0:PatchOp"
-            ],
-            "Operations": [
-                {
-                    "op": "remove",
-                    "value": {
-                        "members": [
-                            {
-                                "value": user.username
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
+        payload = get_payload_for_single_operation("remove", user.username)
         response = self.admin_client.patch(f"/api/scim/v2/Groups/{allocation.id}",
                                            data=payload,
                                            format="json")
@@ -134,47 +122,14 @@ class TestAllocation(base.TestBase):
         project = self.new_project(pi=user)
         allocation = self.new_allocation(project, self.resource, 1)
 
-        # Attempt adding non-existing user
-        payload = {
-            "schemas": [
-                "urn:ietf:params:scim:api:messages:2.0:PatchOp"
-            ],
-            "Operations": [
-                {
-                    "op": "add",
-                    "value": {
-                        "members": [
-                            {
-                                "value": uuid.uuid4().hex
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
+        payload = get_payload_for_single_operation("add", uuid.uuid4().hex)
         response = self.admin_client.patch(f"/api/scim/v2/Groups/{allocation.id}",
                                            data=payload,
                                            format="json")
         self.assertEqual(response.status_code, 400)
 
         # Attempt adding non-existing user, that exists from search
-        payload = {
-            "schemas": [
-                "urn:ietf:params:scim:api:messages:2.0:PatchOp"
-            ],
-            "Operations": [
-                {
-                    "op": "add",
-                    "value": {
-                        "members": [
-                            {
-                                "value": "fake-user-1"
-                            }
-                        ]
-                    }
-                }
-            ]
-        }
+        payload = get_payload_for_single_operation("add", "fake-user-1")
         response = self.admin_client.patch(f"/api/scim/v2/Groups/{allocation.id}",
                                            data=payload,
                                            format="json")

--- a/src/coldfront_plugin_api/utils.py
+++ b/src/coldfront_plugin_api/utils.py
@@ -1,0 +1,50 @@
+from coldfront.core.user import utils as user_utils
+from django.contrib.auth.models import User
+from django.core.exceptions import ObjectDoesNotExist
+
+
+def find_user(username):
+    """Searches for a user in the configured search providers."""
+    search = user_utils.CombinedUserSearch(username, "username_only")
+    results = search.search().get("matches")
+
+    found = None
+    if results:
+        for entry in results:
+            if entry.get("username") == username:
+                found = entry
+
+    return found
+
+
+def create_user(username, first_name, last_name, email):
+    user_obj, _ = User.objects.get_or_create(
+        username=username)
+    user_obj.first_name = first_name
+    user_obj.last_name = last_name
+    user_obj.email = email
+    user_obj.save()
+
+    return user_obj
+
+
+def get_or_fetch_user(username):
+    """
+    Gets user from ColdFront, or creates it with information from configured
+    search providers based on the username.
+
+    Example: If ColdFront is configured to search for users in Keycloak, and
+    the user doesn't exist in ColdFront yet, but does in Keycloak, this method
+    will create the user in ColdFront with the information returned from
+    the identity provider.
+    """
+    try:
+        user = User.objects.get(username=username)
+    except ObjectDoesNotExist:
+        found = find_user(username)
+        if not found:
+            raise
+
+        user = create_user(**found)
+
+    return user


### PR DESCRIPTION
ColdFront allows configuring external search providers when adding a user to a resource allocation, so even if a user doesn't exist in the ColdFront database, if they exist in Keycloak can be added to a project. This is what powers the search function in the web browser version.

This plugs in that functionality to the SCIM v2 Groups API.

Therefore, you can now add a user to a group, if the user doesn't exist in ColdFront, but instead exists in one of the configured search providers, in our case that would be Keycloak.

Additionally, this adds tests and mock and helper modules to keep the code tidy.

For ease of reviewing code improvements that are tangential to the core functionality have been split up into separate commits.

Implements the minimally required functionality from #10 