### PR TITLE
Fixed /scim/v2/User/# endpoint to return 404 instead of 500

### DIFF
--- a/src/coldfront_plugin_api/scim_v2/users.py
+++ b/src/coldfront_plugin_api/scim_v2/users.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.models import User
+from django.http import Http404
 from rest_framework.views import APIView
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
@@ -108,5 +109,8 @@ class UserDetail(APIView):
     permission_classes = [IsAdminUser]
 
     def get(self, request, username, format=None):
-        allocation = User.objects.get(username=username)
+        try:
+            allocation = User.objects.get(username=username)
+        except User.DoesNotExist:
+            return Response(status=404)
         return Response(user_to_api_representation(allocation))

--- a/src/coldfront_plugin_api/scim_v2/users.py
+++ b/src/coldfront_plugin_api/scim_v2/users.py
@@ -1,5 +1,4 @@
 from django.contrib.auth.models import User
-from django.http import Http404
 from rest_framework.views import APIView
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response

--- a/src/coldfront_plugin_api/tests/unit/test_users.py
+++ b/src/coldfront_plugin_api/tests/unit/test_users.py
@@ -2,6 +2,7 @@ from unittest import mock
 import uuid
 
 from coldfront.core.resource import models as resource_models
+from coldfront.core.user.models import User
 from rest_framework.test import APIClient
 
 from coldfront_plugin_api.tests.unit import base, fakes
@@ -82,3 +83,11 @@ class TestUsers(base.TestBase):
         self.assertEqual(user_dict["name"]["givenName"], "fake")
         self.assertEqual(user_dict["name"]["familyName"], "user 1")
         self.assertEqual(user_dict["emails"][0]["value"], "fake_user_1@example.com")
+
+    def test_reseponse_404(self):
+        # Make a http request to scim endpoint
+        fake_username = "9999"
+        self.assertFalse(User.objects.filter(username=fake_username).exists())
+
+        r = self.admin_client.get("/api/scim/v2/Users/9999")
+        self.assertEqual(r.status_code, 404)

--- a/src/coldfront_plugin_api/tests/unit/test_users.py
+++ b/src/coldfront_plugin_api/tests/unit/test_users.py
@@ -85,7 +85,6 @@ class TestUsers(base.TestBase):
         self.assertEqual(user_dict["emails"][0]["value"], "fake_user_1@example.com")
 
     def test_reseponse_404(self):
-        # Make a http request to scim endpoint
         fake_username = "9999"
         self.assertFalse(User.objects.filter(username=fake_username).exists())
 


### PR DESCRIPTION
Fixes https://github.com/nerc-project/coldfront-plugin-api/issues/15 by performing a try-except block around the query call.

The last PR was closed because while trying to reset and rebasing and squashing, I accidentally pushed such that the main branch and my local branch was identical, thus automatically closing the PR?