### PR TITLE
Fixes 500 when user info fetched from Keycloak

### DIFF
--- a/src/coldfront_plugin_api/scim_v2/users.py
+++ b/src/coldfront_plugin_api/scim_v2/users.py
@@ -92,7 +92,12 @@ class ListUsers(APIView):
                 "email": email_list[0].get("value", "")
             }
 
-        user = utils.create_user(**found)
+        user = utils.create_user(
+            username=username,
+            email=found.get("email", ""),
+            first_name=found.get("first_name", ""),
+            last_name=found.get("last_name", ""),
+        )
 
         return Response(user_to_api_representation(user), 201)
 

--- a/src/coldfront_plugin_api/tests/unit/fakes.py
+++ b/src/coldfront_plugin_api/tests/unit/fakes.py
@@ -3,7 +3,8 @@ FAKE_USERS = {
         "username": "fake-user-1",
         "first_name": "fake",
         "last_name": "user 1",
-        "email": "fake_user_1@example.com"
+        "email": "fake_user_1@example.com",
+        "source": "Fake Source"
     }
 }
 

--- a/src/coldfront_plugin_api/utils.py
+++ b/src/coldfront_plugin_api/utils.py
@@ -45,6 +45,11 @@ def get_or_fetch_user(username):
         if not found:
             raise
 
-        user = create_user(**found)
+        user = create_user(
+            username=username,
+            first_name=found.get("first_name", ""),
+            last_name=found.get("last_name", ""),
+            email=found.get("email", ""),
+        )
 
     return user


### PR DESCRIPTION
When creating a users, we first attempt to fetch up to date information from Keycloak. However, when that succeeds, the API returns 500 because the dictionary returned contains an extra key.

TypeError: create_user() got an unexpected keyword argument 'source'.

This fixes the above error by passing only the required keys to create_user.