### PR TITLE
Implemented django_scim for scim/v2/Groups

### DIFF
--- a/src/coldfront_plugin_api/scim_v2/filters.py
+++ b/src/coldfront_plugin_api/scim_v2/filters.py
@@ -1,5 +1,5 @@
-from django_scim.filters import UserFilterQuery
-from django_scim.utils import get_user_model
+from django_scim.filters import UserFilterQuery, GroupFilterQuery
+from django_scim.utils import get_user_model, get_group_model
 
 
 class ColdfrontUserFilterQuery(UserFilterQuery):
@@ -29,3 +29,19 @@ class ColdfrontUserFilterQuery(UserFilterQuery):
         ("givenName", None, None): "first_name",
         ("emails", "value", None): "email",
     }
+
+
+class ColdfrontGroupFilterQuery(GroupFilterQuery):
+    """
+    Implements the attribute mapping and joins for the SCIM Group Object
+    Currently allows queries to filter by group (Coldfront Allocation) members
+    I.e filter=members.value eq "test@bu.edu" will return all groups that user test@bu.edu belongs to
+    """
+
+    model_getter = get_group_model
+    attr_map = {("members", "value", None): "auth_user.username"}
+
+    joins = (
+        "INNER JOIN allocation_allocationuser ON allocation_allocationuser.allocation_id = allocation_allocation.id",
+        "LEFT JOIN auth_user ON auth_user.id = allocation_allocationuser.user_id",
+    )

--- a/src/coldfront_plugin_api/urls.py
+++ b/src/coldfront_plugin_api/urls.py
@@ -6,7 +6,6 @@ from coldfront.core.allocation.models import Allocation
 from django_scim import views as scim_views
 
 from coldfront_plugin_api import auth, serializers
-from coldfront_plugin_api.scim_v2 import groups
 
 
 class AllocationViewSet(viewsets.ReadOnlyModelViewSet):
@@ -31,8 +30,8 @@ router.register(r"allocations", AllocationViewSet, basename="api-allocation")
 urlpatterns = router.urls
 
 urlpatterns += [
-    path("scim/v2/Groups", groups.ListGroups.as_view()),
-    path("scim/v2/Groups/<int:pk>", groups.GroupDetail.as_view()),
+    path("scim/v2/Groups", scim_views.GroupsView.as_view(), name="groups"),
+    path("scim/v2/Groups/<int:uuid>", scim_views.GroupsView.as_view(), name="groups"),
     path("scim/v2", scim_views.SCIMView.as_view(implemented=False), name="root"),
     path("scim/v2/Users", scim_views.UsersView.as_view(), name="users"),
     path("scim/v2/Users/<str:uuid>", scim_views.UsersView.as_view(), name="users"),

--- a/src/coldfront_plugin_api/utils.py
+++ b/src/coldfront_plugin_api/utils.py
@@ -1,6 +1,6 @@
 from coldfront.core.user import utils as user_utils
 from django.contrib.auth.models import User
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 
 
 def find_user(username):
@@ -55,4 +55,11 @@ def get_or_fetch_user(username):
 
 
 def is_user_superuser(user: User):
-    return user.is_superuser
+    """
+    As a temporary hack, this function will handle raising the appropriate 403 error if
+    user is authenticated, but not superuser
+    """
+    if user.is_authenticated and not user.is_superuser:
+        raise PermissionDenied
+    else:
+        return user.is_authenticated

--- a/src/local_settings.py
+++ b/src/local_settings.py
@@ -32,5 +32,8 @@ SCIM_SERVICE_PROVIDER = {
     "NETLOC": "localhost",
     "USER_ADAPTER": "coldfront_plugin_api.scim_v2.adapter_user.SCIMColdfrontUser",
     "USER_FILTER_PARSER": "coldfront_plugin_api.scim_v2.filters.ColdfrontUserFilterQuery",
+    "GROUP_MODEL": "coldfront.core.allocation.models.Allocation",  # Because our SCIM Group is an allocation
+    "GROUP_ADAPTER": "coldfront_plugin_api.scim_v2.adapter_group.SCIMColdfrontGroup",
+    "GROUP_FILTER_PARSER": "coldfront_plugin_api.scim_v2.filters.ColdfrontGroupFilterQuery",
     "GET_IS_AUTHENTICATED_PREDICATE": "coldfront_plugin_api.utils.is_user_superuser",
 }


### PR DESCRIPTION
#33, I used django_scim for the SCIM Group API, and for now have added the ability to filter the group based on user membership.

An example filter is: /scim/v2/Groups?filter=members.value eq "test@bu.edu" will return groups with a member whose username or email is test@bu.edu