### PR TITLE
Added filtering of allocations by several attributes

### DIFF
--- a/src/coldfront_plugin_api/tests/unit/test_allocations.py
+++ b/src/coldfront_plugin_api/tests/unit/test_allocations.py
@@ -4,6 +4,7 @@ import sys
 from coldfront.core.allocation import models as allocation_models
 from django.core.management import call_command
 from coldfront_plugin_cloud.tests import base
+from coldfront_plugin_cloud import attributes
 from rest_framework.test import APIClient
 
 
@@ -17,6 +18,17 @@ class TestAllocation(base.TestBase):
         sys.stdout = backup
 
         self.resource = self.new_resource(name="Devstack", auth_url="http://localhost")
+
+    @staticmethod
+    def new_allocation_attribute(allocation, attribute, value):
+        au, _ = allocation_models.AllocationAttribute.objects.get_or_create(
+            allocation=allocation,
+            allocation_attribute_type=allocation_models.AllocationAttributeType.objects.get(
+                name=attribute
+            ),
+            value=value,
+        )
+        return au
 
     @property
     def admin_client(self):
@@ -55,3 +67,80 @@ class TestAllocation(base.TestBase):
         response = self.admin_client.get("/api/allocations?all=true")
         self.assertEqual(response.status_code, 200)
         self.assertIn(allocation.id, [a["id"] for a in response.json()])
+
+    def test_filter_allocations(self):
+        user1 = self.new_user()
+        project1 = self.new_project(pi=user1)
+        project2 = self.new_project(pi=user1)
+        allocation1 = self.new_allocation(project1, self.resource, 1)
+        allocation2 = self.new_allocation(project1, self.resource, 2)
+        allocation3 = self.new_allocation(project2, self.resource, 1)
+        aa1 = self.new_allocation_attribute(allocation1, attributes.QUOTA_LIMITS_CPU, 1)
+        self.new_allocation_attribute(allocation2, attributes.QUOTA_LIMITS_CPU, 1)
+        aa3 = self.new_allocation_attribute(allocation3, attributes.QUOTA_LIMITS_CPU, 3)
+        aa4 = self.new_allocation_attribute(
+            allocation1, attributes.QUOTA_LIMITS_MEMORY, 64
+        )
+        self.new_allocation_attribute(allocation2, attributes.QUOTA_LIMITS_MEMORY, 128)
+        self.new_allocation_attribute(allocation3, attributes.QUOTA_LIMITS_MEMORY, 64)
+
+        # Filter by project title
+        r_json = self.admin_client.get(
+            f"/api/allocations?project__title={project1.title}"
+        ).json()
+        self.assertEqual(len(r_json), 2)
+        self.assertEqual(r_json[0]["project"]["title"], project1.title)
+
+        # Filter by project pi email
+        r_json = self.admin_client.get(
+            f"/api/allocations?project__pi__email={user1.email}"
+        ).json()
+        self.assertEqual(len(r_json), 3)
+        self.assertEqual(r_json[0]["project"]["pi"], user1.email)
+
+        # Filter by resource type
+        r_json = self.admin_client.get(
+            f"/api/allocations?resources__resource_type__name={self.resource.resource_type.name}"
+        ).json()
+        self.assertEqual(len(r_json), 3)
+        self.assertEqual(
+            r_json[0]["resource"]["resource_type"], self.resource.resource_type.name
+        )
+
+        # Filter by 1 attribute with conditional or
+        r_json = self.admin_client.get(
+            "/api/allocations?attr_{}={}&attr_{}={}".format(
+                attributes.QUOTA_LIMITS_CPU,
+                aa1.value,
+                attributes.QUOTA_LIMITS_CPU,
+                aa3.value,
+            )
+        ).json()
+        self.assertEqual(len(r_json), 3)
+        self.assertIn(attributes.QUOTA_LIMITS_CPU, r_json[0]["attributes"])
+
+        # Filter by two allocation attributes, with conditional or
+        r_json = self.admin_client.get(
+            "/api/allocations?attr_{}={}&attr_{}={}".format(
+                attributes.QUOTA_LIMITS_CPU,
+                aa1.value,
+                attributes.QUOTA_LIMITS_MEMORY,
+                aa4.value,
+            )
+        ).json()
+        self.assertEqual(len(r_json), 1)
+        self.assertEqual(
+            r_json[0]["attributes"][attributes.QUOTA_LIMITS_CPU], aa1.value
+        )
+        self.assertEqual(
+            r_json[0]["attributes"][attributes.QUOTA_LIMITS_MEMORY], aa4.value
+        )
+
+        # Filter by non-existant attribute
+        r_json = self.admin_client.get("/api/allocations?attr_fake=fake").json()
+        self.assertEqual(r_json, [])
+
+        r_json = self.admin_client.get(
+            "/api/allocations?fake_model_attribute=fake"
+        ).json()
+        self.assertEqual(r_json, [])

--- a/src/coldfront_plugin_api/urls.py
+++ b/src/coldfront_plugin_api/urls.py
@@ -2,6 +2,8 @@ from rest_framework import routers, viewsets
 from rest_framework.permissions import IsAdminUser
 from rest_framework.urlpatterns import format_suffix_patterns
 from django.urls import path
+from django.db.models import Q
+from django.core.exceptions import FieldError
 from coldfront.core.allocation.models import Allocation
 from django_scim import views as scim_views
 
@@ -10,15 +12,77 @@ from coldfront_plugin_api.scim_v2 import groups
 
 
 class AllocationViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    This viewset implements the API to Coldfront's allocation object
+    The API allows filtering allocations by any of Coldfront's allocation model attributes,
+    as well as by Allocation Attributes.
+
+    Filtering by allocation model attributes
+    (i.e by pk, start_date, or even by attributes that span relationships, like project PI email)
+    is possible by using the query parameters directly as Django query filters.
+
+    For example, to filter by the allocation's project PI email: "/api/allocations?project__pi__email=test@bu.edu"
+
+    Filtering using this method requires knowledge of the Allocation model schema and Django's filters
+    Documentation of Coldfront Allocation model: https://coldfront.readthedocs.io/en/latest/apidocs/allocations/
+    Documentation for Django's query syntax: https://docs.djangoproject.com/en/5.0/topics/db/queries/#lookups-that-span-relationships
+
+    To filter by allocation attribute (AA) (i.e Quota Limits CPU),
+    name the query as the AA (case insensitive), prefixed with "attr_"
+
+    For all filters, you can also filter with conditional OR for the same model attribute or AA
+    I.e, to find allocations with AA Quota Limits CPU equal to 2 OR 4:
+    "/api/allocations?attr_quota limits cpu=2&attr_quota limits cpu=4"
+    Note the presence of spaces in the AA names
+
+    Filtering with conditional AND on two or more attributes is also possible
+    I.e, to filter for allocations with AA Quota Limits CPU equal 2 AND Quota RAM equals 4G:
+    "/api/allocations?attr_quota limits cpu=2&attr_quota ram=4G"
+
+    In cases where an invalid model attribute or AA is queried, an empty list is returned
+    """
+
     serializer_class = serializers.AllocationSerializer
     authentication_classes = auth.AUTHENTICATION_CLASSES
     permission_classes = [IsAdminUser]
 
     def get_queryset(self):
         queryset = Allocation.objects.filter(status__name="Active")
+        query_params = self.request.query_params
 
-        if self.request.query_params.get("all") == "true":
+        if query_params.get("all") == "true":
             queryset = Allocation.objects.all()
+
+        allocation_attr_prefix = "attr_"
+
+        for query, val in query_params.items():
+            if query == "all":
+                continue
+            if query.startswith(allocation_attr_prefix):
+                attribute_query = query[len(allocation_attr_prefix) :]
+                val_list = query_params.getlist(query)
+
+                # Using Django's Q object to create OR query for attribute
+                # https://docs.djangoproject.com/en/5.0/topics/db/queries/#complex-lookups-with-q-objects
+                q_query = Q()
+                for val in val_list:
+                    q_query = q_query | Q(allocationattribute__value=val)
+
+                queryset = queryset.filter(
+                    q_query,
+                    allocationattribute__allocation_attribute_type__name__iexact=attribute_query,
+                )
+
+            else:
+                val_list = query_params.getlist(query)
+                q_query = Q()
+                for val in val_list:
+                    q_query = q_query | Q(**{query: val})
+
+                try:
+                    queryset = queryset.filter(q_query)
+                except FieldError:
+                    queryset = queryset.none()
 
         return queryset
 


### PR DESCRIPTION
Closes #30  Specifically, I have added filtering by project PI email, project title, resource name, resource type, and allocation id. This feature is implemented by creating a mapping between the query arguements and the django model query arguements. More details in my [comments](https://github.com/nerc-project/coldfront-plugin-api/compare/main...QuanMPhm:30/allocation_api?expand=1#diff-2be8627f55e66e9de9bf3b91fd9f2d48179167ccdeee11ca3e5801696fdd4b1bR13) to the allocations viewset.