### PR TITLE
Modified /api/allocations endpoint to return PI email instead of user…

### DIFF
--- a/src/coldfront_plugin_api/serializers.py
+++ b/src/coldfront_plugin_api/serializers.py
@@ -14,7 +14,7 @@ class ProjectSerializer(serializers.ModelSerializer):
     status = serializers.SerializerMethodField()
 
     def get_pi(self, obj: Project) -> str:
-        return obj.pi.username
+        return obj.pi.email
 
     def get_field_of_science(self, obj: Project) -> str:
         return obj.field_of_science.description


### PR DESCRIPTION
Closes #39. I changed `get_pi()` to return the PI's email instead of username.