### PR TITLE
Moved django_scim settings into config.py

### DIFF
--- a/src/coldfront_plugin_api/config.py
+++ b/src/coldfront_plugin_api/config.py
@@ -4,3 +4,14 @@ from coldfront.config.env import ENV  # noqa: F401
 for app in ["rest_framework", "coldfront_plugin_api", "django_scim"]:
     if app not in INSTALLED_APPS:
         INSTALLED_APPS.append(app)
+
+# Settings for django_scim module
+SCIM_SERVICE_PROVIDER = {
+    "NETLOC": "localhost",
+    "USER_ADAPTER": "coldfront_plugin_api.scim_v2.adapter_user.SCIMColdfrontUser",
+    "USER_FILTER_PARSER": "coldfront_plugin_api.scim_v2.filters.ColdfrontUserFilterQuery",
+    "GROUP_MODEL": "coldfront.core.allocation.models.Allocation",  # Because our SCIM Group is an allocation
+    "GROUP_ADAPTER": "coldfront_plugin_api.scim_v2.adapter_group.SCIMColdfrontGroup",
+    "GROUP_FILTER_PARSER": "coldfront_plugin_api.scim_v2.filters.ColdfrontGroupFilterQuery",
+    "GET_IS_AUTHENTICATED_PREDICATE": "coldfront_plugin_api.utils.is_user_superuser",
+}

--- a/src/local_settings.py
+++ b/src/local_settings.py
@@ -26,14 +26,3 @@ if os.getenv("PLUGIN_AUTH_OIDC") == "True":
     REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"].append(
         "mozilla_django_oidc.contrib.drf.OIDCAuthentication",
     )
-
-# Settings for django_scim module
-SCIM_SERVICE_PROVIDER = {
-    "NETLOC": "localhost",
-    "USER_ADAPTER": "coldfront_plugin_api.scim_v2.adapter_user.SCIMColdfrontUser",
-    "USER_FILTER_PARSER": "coldfront_plugin_api.scim_v2.filters.ColdfrontUserFilterQuery",
-    "GROUP_MODEL": "coldfront.core.allocation.models.Allocation",  # Because our SCIM Group is an allocation
-    "GROUP_ADAPTER": "coldfront_plugin_api.scim_v2.adapter_group.SCIMColdfrontGroup",
-    "GROUP_FILTER_PARSER": "coldfront_plugin_api.scim_v2.filters.ColdfrontGroupFilterQuery",
-    "GET_IS_AUTHENTICATED_PREDICATE": "coldfront_plugin_api.utils.is_user_superuser",
-}


### PR DESCRIPTION
Closes #37. This allows django_scim to be proper configured when `coldfront-plugin-api` is imported into another project.