### PR TITLE
Upgrade python version

### DIFF
--- a/.github/workflows/test-py39-functional-scim-auth.yaml
+++ b/.github/workflows/test-py39-functional-scim-auth.yaml
@@ -14,10 +14,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
-      - name: Set up python
+      - name: Set up python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.12
 
       - name: Run keycloak container
         run: |

--- a/.github/workflows/test-py39-unit.yaml
+++ b/.github/workflows/test-py39-unit.yaml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.12
 
       - name: Install ColdFront and plugin
         run: |


### PR DESCRIPTION
As part of [upgrading Python to 3.12](https://github.com/nerc-project/coldfront-nerc/issues/128), the CI python versions have been upgraded. 

While testing this PR, it was found that coldfront-plugin-api now fails its CI checks due to various which I have outlined in #49 