### PR TITLE
Fixed unit and functional tests

### DIFF
--- a/ci/run_keycloak.sh
+++ b/ci/run_keycloak.sh
@@ -5,4 +5,4 @@ sudo docker run -d --name keycloak \
     -e KEYCLOAK_ADMIN_PASSWORD=nomoresecret \
     -p 8080:8080 \
     -p 8443:8443 \
-    quay.io/keycloak/keycloak:latest start-dev
+    quay.io/keycloak/keycloak:25.0 start-dev

--- a/src/coldfront_plugin_api/tests/unit/test_allocations.py
+++ b/src/coldfront_plugin_api/tests/unit/test_allocations.py
@@ -17,7 +17,9 @@ class TestAllocation(base.TestBase):
         call_command("register_cloud_attributes")
         sys.stdout = backup
 
-        self.resource = self.new_resource(name="Devstack", auth_url="http://localhost")
+        self.resource = self.new_openstack_resource(
+            name="Devstack", auth_url="http://localhost"
+        )
 
     @staticmethod
     def new_allocation_attribute(allocation, attribute, value):


### PR DESCRIPTION
While submitting the PR to upgrade the Python version in our CI to 3.12 (#48). Several workflows have failed. The causes of these (as far as I could tell) were:

- For unit tests, due to an [update](https://github.com/nerc-project/coldfront-plugin-cloud/blob/3cc766c46b0541109df5a8fed3c2e675d2b065f7/src/coldfront_plugin_cloud/tests/base.py#L65) to the test base in `coldfront_plugin_cloud`, a [function call](https://github.com/nerc-project/coldfront-plugin-api/blob/45a880b21c00078cecc9807c0028ef6587324908/src/coldfront_plugin_api/tests/unit/test_allocations.py#L20) in one of our unit tests became out-of-date
- For functional tests, our [Keycloak client code](https://github.com/nerc-project/coldfront-plugin-api/blob/45a880b21c00078cecc9807c0028ef6587324908/src/coldfront_plugin_api/tests/functional/utils.py#L25) no longer seemed to work because of breaking changes introduced in the latest version of the Keycloak image. Pinning the version of the Keycloak image to the one before this repo's last CI check will allow the functional test to pass. @knikolla @larsks @naved001 Is it fine to pin the keycloak container version? I have not added the pin in this PR