### PR TITLE
Allow creating and updating allocations with API versioning

### DIFF
--- a/src/coldfront_plugin_api/serializers.py
+++ b/src/coldfront_plugin_api/serializers.py
@@ -1,14 +1,29 @@
+import logging
+from datetime import datetime, timedelta
+
 from rest_framework import serializers
 
-from coldfront.core.allocation.models import Allocation, AllocationAttribute
-from coldfront.core.allocation.models import Project
+from coldfront.core.allocation.models import (
+    Allocation,
+    AllocationAttribute,
+    AllocationStatusChoice,
+    AllocationAttributeType,
+)
+from coldfront.core.allocation.models import Project, Resource
+from coldfront.core.allocation import signals
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 class ProjectSerializer(serializers.ModelSerializer):
     class Meta:
         model = Project
         fields = ["id", "title", "pi", "description", "field_of_science", "status"]
+        read_only_fields = ["title", "pi", "description", "field_of_science", "status"]
 
+    id = serializers.IntegerField()
     pi = serializers.SerializerMethodField()
     field_of_science = serializers.SerializerMethodField()
     status = serializers.SerializerMethodField()
@@ -21,6 +36,35 @@ class ProjectSerializer(serializers.ModelSerializer):
 
     def get_status(self, obj: Project) -> str:
         return obj.status.name
+
+
+class AllocationAttributeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = AllocationAttribute
+        fields = ["attribute_type", "value"]
+
+    attribute_type = (
+        serializers.SlugRelatedField(  # Peforms validation to ensure attribute exists
+            read_only=False,
+            slug_field="name",
+            queryset=AllocationAttributeType.objects.all(),
+            source="allocation_attribute_type",
+        )
+    )
+    value = serializers.CharField(read_only=False)
+
+
+class ResourceSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Resource
+        fields = ["id", "name", "resource_type"]
+
+    id = serializers.IntegerField()
+    name = serializers.CharField(required=False)
+    resource_type = serializers.SerializerMethodField(required=False)
+
+    def get_resource_type(self, obj: Resource):
+        return obj.resource_type.name
 
 
 class AllocationSerializer(serializers.ModelSerializer):
@@ -48,3 +92,70 @@ class AllocationSerializer(serializers.ModelSerializer):
 
     def get_status(self, obj: Allocation) -> str:
         return obj.status.name
+
+
+class AllocationSerializerV2(serializers.ModelSerializer):
+    class Meta:
+        model = Allocation
+        fields = ["id", "project", "description", "resources", "status", "attributes"]
+
+    resources = ResourceSerializer(many=True)
+    project = ProjectSerializer()
+    attributes = AllocationAttributeSerializer(
+        many=True, source="allocationattribute_set", required=False
+    )
+    status = serializers.SlugRelatedField(
+        slug_field="name", queryset=AllocationStatusChoice.objects.all()
+    )
+
+    def create(self, validated_data):
+        project_obj = Project.objects.get(id=validated_data["project"]["id"])
+        resource_obj = Resource.objects.get(id=validated_data["resources"][0]["id"])
+        allocation = Allocation.objects.create(
+            project=project_obj,
+            status=validated_data["status"],
+            justification="",
+            start_date=datetime.now(),
+            end_date=datetime.now() + timedelta(days=365),
+        )
+        allocation.resources.add(resource_obj)
+        allocation.save()
+
+        for attribute in validated_data.pop("allocationattribute_set", []):
+            AllocationAttribute.objects.create(
+                allocation=allocation,
+                allocation_attribute_type=attribute["allocation_attribute_type"],
+                value=attribute["value"],
+            )
+
+        logger.info(
+            f"Created allocation {allocation.id} for project {project_obj.title}"
+        )
+        return allocation
+
+    def update(self, allocation: Allocation, validated_data):
+        """
+        Only allow updating allocation status for now
+
+        Certain status transitions will have side effects (activating/deactivating allocations)
+        """
+
+        old_status = allocation.status.name
+        new_status = validated_data.get("status", old_status).name
+
+        allocation.status = validated_data.get("status", allocation.status)
+        allocation.save()
+
+        if old_status == "New" and new_status == "Active":
+            signals.allocation_activate.send(
+                sender=self.__class__, allocation_pk=allocation.pk
+            )
+        elif old_status == "Active" and new_status in ["Denied", "Revoked"]:
+            signals.allocation_disable.send(
+                sender=self.__class__, allocation_pk=allocation.pk
+            )
+
+        logger.info(
+            f"Updated allocation {allocation.id} for project {allocation.project.title}"
+        )
+        return allocation

--- a/src/coldfront_plugin_api/urls.py
+++ b/src/coldfront_plugin_api/urls.py
@@ -10,7 +10,7 @@ from django_scim import views as scim_views
 from coldfront_plugin_api import auth, serializers
 
 
-class AllocationViewSet(viewsets.ReadOnlyModelViewSet):
+class AllocationViewSet(viewsets.ModelViewSet):
     """
     This viewset implements the API to Coldfront's allocation object
     The API allows filtering allocations by any of Coldfront's allocation model attributes,
@@ -41,9 +41,13 @@ class AllocationViewSet(viewsets.ReadOnlyModelViewSet):
     In cases where an invalid model attribute or AA is queried, an empty list is returned
     """
 
-    serializer_class = serializers.AllocationSerializer
     authentication_classes = auth.AUTHENTICATION_CLASSES
     permission_classes = [IsAdminUser]
+
+    def get_serializer_class(self):
+        if self.request.version == "2.0":
+            return serializers.AllocationSerializerV2
+        return serializers.AllocationSerializer
 
     def get_queryset(self):
         queryset = Allocation.objects.filter(status__name="Active")

--- a/src/local_settings.py
+++ b/src/local_settings.py
@@ -20,6 +20,7 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.BasicAuthentication",
         "rest_framework.authentication.SessionAuthentication",
     ],
+    "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.AcceptHeaderVersioning",
 }
 
 if os.getenv("PLUGIN_AUTH_OIDC") == "True":


### PR DESCRIPTION
Counterpart to #52, which implements API versioning, so that the `create` and `update` methods are available in `v2` of the API. API versioning is done through DRF's [header versioning](https://www.django-rest-framework.org/api-guide/versioning/#acceptheaderversioning)